### PR TITLE
Add pluggable SASL and NickServ authentication adapters

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+build --cxxopt='-std=c++23'
+build --host_cxxopt='-std=c++23'
+
+build --compiler=gcc-13
+build --action_env=CC=/usr/bin/gcc-13
+build --action_env=CXX=/usr/bin/g++-13

--- a/lib/irc-client/ArgParser.hpp
+++ b/lib/irc-client/ArgParser.hpp
@@ -22,6 +22,15 @@ struct ParsedArgs
     std::string logPath;
     std::string listenSocket;
     std::string instance;
+
+    enum class AuthMode
+    {
+        None,
+        NickServ,
+        SASL
+    } authMode = AuthMode::None;
+    bool useSasl = false; // set by --sasl
+    std::string password;
 };
 
 class ArgParser

--- a/lib/irc-client/AuthStrategy.hpp
+++ b/lib/irc-client/AuthStrategy.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include "IRCClient.hpp"
+
+// Pluggable auth strategy interface
+struct AuthStrategy
+{
+	virtual ~AuthStrategy() = default;
+	// Perform whatever handshake is needed before NICK/USER
+	virtual void negotiate(IRCClient &client) = 0;
+};

--- a/lib/irc-client/BUILD.bazel
+++ b/lib/irc-client/BUILD.bazel
@@ -68,11 +68,22 @@ cc_library(
 
 cc_library(
     name = "irc_client_lib",
-    srcs = ["IRCClient.cpp"],
+    srcs = [
+        "IRCClient.cpp",
+        # new auth adapter implementations:
+        "SaslAdapter.cpp",
+        "NickServAdapter.cpp",
+    ],
     hdrs = [
         "IOAdapter.hpp",
         "IRCClient.hpp",
         "IRCEventKeys.hpp",
+        # new auth adapter headers:
+        "AuthStrategy.hpp",
+        "SaslAdapter.hpp",
+        "NickServAdapter.hpp",
+        # Base64 helper:
+        "Base64.hpp",
     ],
     copts = COPTS_CXX23,
     includes = ["Commands"],

--- a/lib/irc-client/BUILD.bazel
+++ b/lib/irc-client/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
+COPTS_CXX23 = ["-std=c++23"]
+
 cc_library(
     name = "irc_core",
     hdrs = [
@@ -32,7 +34,7 @@ cc_library(
         "IOAdapter.hpp",
         "NcursesUI.hpp",
     ],
-    copts = ["-std=c++23"],
+    copts = COPTS_CXX23,
     visibility = ["//visibility:public"],
 )
 
@@ -44,7 +46,7 @@ cc_library(
         "Logger.hpp",
         "UnixSocketUI.hpp",
     ],
-    copts = ["-std=c++23"],
+    copts = COPTS_CXX23,
     visibility = ["//visibility:public"],
 )
 
@@ -72,7 +74,7 @@ cc_library(
         "IRCClient.hpp",
         "IRCEventKeys.hpp",
     ],
-    copts = ["-std=c++23"],
+    copts = COPTS_CXX23,
     includes = ["Commands"],
     visibility = ["//visibility:public"],
     deps = [
@@ -96,6 +98,8 @@ cc_binary(
     linkopts = [
         "-lncurses",
         "-lpthread",
+        "-lssl",
+        "-lcrypto",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/lib/irc-client/Base64.hpp
+++ b/lib/irc-client/Base64.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <string>
+
+// Minimal Base64 encoder
+static const char *B64_CHARS =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+inline std::string encodeBase64(const std::string &in)
+{
+	std::string out;
+	int val = 0, valb = -6;
+
+	for (char ch : in)
+	{
+		unsigned char c = static_cast<unsigned char>(ch);
+		val = (val << 8) + c;
+		valb += 8;
+		while (valb >= 0)
+		{
+			out.push_back(B64_CHARS[(val >> valb) & 0x3F]);
+			valb -= 6;
+		}
+	}
+
+	if (valb > -6)
+	{
+		out.push_back(
+			B64_CHARS[((val << 8) >> (valb + 8)) & 0x3F]);
+	}
+	while (out.size() % 4)
+	{
+		out.push_back('=');
+	}
+	return out;
+}

--- a/lib/irc-client/Commands/InputCommand.hpp
+++ b/lib/irc-client/Commands/InputCommand.hpp
@@ -20,6 +20,6 @@ inline Command InputCommand{
 	{
 		std::string raw = input.substr(7); // strip "/input "
 		std::string message = raw + "\n";
-		asio::write(client.getSocket(), asio::buffer(message));
+		client.sendRaw(message);
 		client.getLogger().log("→ " + raw);
 	}};

--- a/lib/irc-client/Commands/InputCommand.hpp
+++ b/lib/irc-client/Commands/InputCommand.hpp
@@ -20,6 +20,6 @@ inline Command InputCommand{
 	{
 		std::string raw = input.substr(7); // strip "/input "
 		std::string message = raw + "\n";
-		client.sendRaw(message);
+		client.writeToServer(message);
 		client.getLogger().log("→ " + raw);
 	}};

--- a/lib/irc-client/IRCClient.hpp
+++ b/lib/irc-client/IRCClient.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <asio.hpp>
 #include <asio/ssl.hpp>
+
 #include <atomic>
 #include <functional>
 #include <map>
@@ -17,6 +18,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <stdexcept>
 
 #include "Channel.hpp"
 #include "Commands/Command.hpp"
@@ -34,6 +36,12 @@ public:
 
 	IRCClient(asio::io_context &context, Logger &logger, IOAdapter &ui, const std::vector<std::string> &channels);
 
+	~IRCClient();
+
+	/**
+	 * Establish a connection to `server:port`.
+	 * If port==6697, performs a TLS handshake (may throw std::runtime_error on failure).
+	 */
 	void connect(const std::string &server, int port);
 	void authenticate(const std::string &nick, const std::string &user, const std::string &realname);
 	void startInputLoop();
@@ -41,9 +49,9 @@ public:
 	void joinInputLoop();
 	void stop();
 	void signoff(const std::map<std::string, Channel> &channels, const std::string &quitMessage);
+	void writeToServer(const std::string &message);
 
 	void joinChannels(const std::vector<std::string> &channels);
-	void sendRaw(const std::string &line);
 
 	void addEventHandler(const std::string &eventKey, std::function<void(IRCClient &, const std::string &)> handler);
 
@@ -74,7 +82,6 @@ private:
 	void registerCommands();
 	void sanitizeInput(std::string &input);
 
-	void writeToServer(const std::string &message);
 	std::size_t readFromServer(char *data, std::size_t size);
 
 	template <typename SocketType>

--- a/lib/irc-client/IRCEventKeys.hpp
+++ b/lib/irc-client/IRCEventKeys.hpp
@@ -12,4 +12,5 @@ struct IRCEventKey
 	static constexpr const char *MotdEnd = "MOTD_END";
 	static constexpr const char *Privmsg = "PRIVMSG";
 	static constexpr const char *Whois = "WHOIS";
+	static constexpr const char *Cap = "CAP"; // for CAP * LS / ACK
 };

--- a/lib/irc-client/NickServAdapter.cpp
+++ b/lib/irc-client/NickServAdapter.cpp
@@ -1,0 +1,11 @@
+#include "NickServAdapter.hpp"
+#include "IRCEventKeys.hpp"
+
+void NickServAdapter::negotiate(IRCClient &client)
+{
+	client.addEventHandler(IRCEventKey::MotdEnd,
+						   [this](IRCClient &c, const std::string &)
+						   {
+							   c.writeToServer("PRIVMSG NickServ :IDENTIFY " + pass_ + "\n");
+						   });
+}

--- a/lib/irc-client/NickServAdapter.hpp
+++ b/lib/irc-client/NickServAdapter.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "AuthStrategy.hpp"
+#include <string>
+
+struct NickServAdapter final : AuthStrategy
+{
+	explicit NickServAdapter(std::string pass)
+		: pass_(std::move(pass)) {}
+
+	void negotiate(IRCClient &client) override;
+
+private:
+	std::string pass_;
+};

--- a/lib/irc-client/SaslAdapter.cpp
+++ b/lib/irc-client/SaslAdapter.cpp
@@ -1,0 +1,57 @@
+#include "SaslAdapter.hpp"
+#include "Base64.hpp"
+#include "IRCEventKeys.hpp"
+#include <asio/write.hpp>
+#include <functional>
+
+void SaslAdapter::negotiate(IRCClient &client)
+{
+	// CAP LS
+	client.writeToServer("CAP LS 302\n");
+	// wait for CAP * LS reply and check for "sasl" in it
+	client.addEventHandler(IRCEventKey::Cap,
+						   [&](IRCClient &, const std::string &line)
+						   {
+							   if (line.find("sasl") != std::string::npos && line.rfind("CAP * LS", 0) == 0)
+							   {
+								   client.writeToServer("CAP REQ :sasl\n");
+							   }
+						   });
+
+	// after ACK, send AUTHENTICATE
+	client.addEventHandler(IRCEventKey::Cap,
+						   [&](IRCClient &, const std::string &line)
+						   {
+							   if (line == "CAP * ACK :sasl")
+							   {
+								   // Build PLAIN payload from stored user_ and pass_
+								   std::string raw = user_ + '\0' + user_ + '\0' + pass_;
+								   std::string b64 = encodeBase64(raw);
+								   client.writeToServer("AUTHENTICATE " + b64 + "\n");
+							   }
+						   });
+
+	// Handle numeric replies:
+	// Success → finish cap
+	client.addEventHandler("903",
+						   [&](IRCClient &, const std::string &)
+						   {
+							   client.writeToServer("CAP END\n");
+						   });
+
+	// Failures: 904–907
+	auto makeHandler = [&](const char *code, const char *msg)
+	{
+		client.addEventHandler(code,
+							   [code, msg](IRCClient &c, const std::string &line)
+							   {
+								   std::string out = std::string("! SASL error (") + code + "): " + msg;
+								   c.getLogger().log(out);
+								   c.getUi().drawOutput(out);
+							   });
+	};
+	makeHandler("904", "SASL authentication failed");
+	makeHandler("905", "SASL mechanism too long");
+	makeHandler("906", "SASL aborted");
+	makeHandler("907", "SASL already in progress");
+}

--- a/lib/irc-client/SaslAdapter.hpp
+++ b/lib/irc-client/SaslAdapter.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "AuthStrategy.hpp"
+#include <string>
+
+struct SaslAdapter final : AuthStrategy
+{
+	// Now takes both user and pass
+	SaslAdapter(std::string user, std::string pass)
+		: user_(std::move(user)), pass_(std::move(pass)) {}
+
+	void negotiate(IRCClient &client) override;
+
+private:
+	std::string user_;
+	std::string pass_;
+};

--- a/lib/irc-client/main.cpp
+++ b/lib/irc-client/main.cpp
@@ -6,6 +6,9 @@
 
 #include "IRCClient.hpp"
 #include "IRCEventKeys.hpp"
+#include "AuthStrategy.hpp"
+#include "SaslAdapter.hpp"
+#include "NickServAdapter.hpp"
 #include "NcursesUI.hpp"
 #include "UnixSocketUI.hpp"
 #include "Logger.hpp"
@@ -83,6 +86,26 @@ int main(int argc, char *argv[])
 
         // Start client connection
         client.connect(args.server, args.port);
+
+        // 1) Choose adapter
+        std::unique_ptr<AuthStrategy> auth;
+        if (args.useSasl)
+        {
+            // Pass the realname (unique user key) plus the password
+            auth = std::make_unique<SaslAdapter>(
+                args.realname,
+                args.password);
+        }
+        else
+        {
+            auth = std::make_unique<NickServAdapter>(
+                args.password);
+        }
+
+        // 2) Run negotiation
+        auth->negotiate(client);
+
+        // 3) Proceed with the normal NICK/USER
         client.authenticate(args.nick, args.user, args.realname);
 
         // Start background input thread (now joinable)


### PR DESCRIPTION
* Extend ArgParser to consolidate credentials:
    * add `--sasl` flag (`args.useSasl`) to select SASL strategy
    * remove separate SASL and NickServ password args in favor of a single `--password`
* Add `AuthStrategy` interface to unify authentication flows
* Introduce `SaslAdapter`:
    * full IRCv3 CAP LS → CAP REQ → AUTHENTICATE → CAP END sequence
    * encode PLAIN payload using new `Base64.hpp` helper
    * implement handlers for numerics 903 (success) and 904–907 (failures), logging and pushing errors to UI
* Introduce `NickServAdapter` for legacy networks:
    * send `PRIVMSG NickServ :IDENTIFY <password>` immediately after MOTD end
* Add `Base64.hpp` as a minimal Base64 encoder for SASL payloads
* Update `IRCEventKeys.hpp` to include `CAP` for listening to capability lines
* Modify `main.cpp` to:
    * choose between `SaslAdapter` and `NickServAdapter` based on `useSasl`
    * invoke `auth->negotiate(client)` before calling `client.authenticate(...)`
* Update `BUILD.bazel`:
    * include `AuthStrategy.hpp`, `SaslAdapter.*`, `NickServAdapter.*`, and `Base64.hpp` in `irc_client_lib`
    * ensure new sources and headers are part of the build graph